### PR TITLE
Hack to use the timeseries calls to retrieve the data

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -2,7 +2,7 @@ valid_trip_columns = [
     "data.source",
     "data.start_ts",
     "data.start_local_dt",
-    "data.start_fmt_tm",
+    "data.start_fmt_time",
     "data.start_place",
     "data.start_loc",
     "data.end_ts",

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -1,8 +1,12 @@
 from datetime import datetime, timezone
+import sys
 
 import pandas as pd
+import logging
 
 import emission.core.get_database as edb
+import emission.storage.timeseries.abstract_timeseries as esta
+import emission.storage.timeseries.timequery as estt
 
 from utils.permissions import get_trips_columns, get_additional_trip_columns
 
@@ -24,11 +28,18 @@ def query_uuids(start_date, end_date):
         'update_ts': 1
     }
 
-    query_result = edb.get_uuid_db().find(query, projection)
-    df = pd.json_normalize(list(query_result))
+    # This should actually use the profile DB instead of (or in addition to)
+    # the UUID DB so that we can see the app version, os, manufacturer...
+    # I will write a couple of functions to get all the users in a time range
+    # (although we should define what that time range should be) and to merge
+    # that with the profile data
+    entries = edb.get_uuid_db().find()
+    df = pd.json_normalize(list(entries))
     if not df.empty:
         df['update_ts'] = pd.to_datetime(df['update_ts'])
-        df['user_id'] = df['user_id'].apply(str)
+        df['user_id'] = df['uuid'].apply(str)
+        df['user_token'] = df['user_email']
+        df.drop(columns=["uuid", "_id"], inplace=True)
     return df
 
 def query_confirmed_trips(start_date, end_date):
@@ -62,10 +73,23 @@ def query_confirmed_trips(start_date, end_date):
     for column in get_additional_trip_columns():
         projection[column['label']] = column['path']
 
-    query_result = edb.get_analysis_timeseries_db().find(query, projection)
-    df = pd.json_normalize(list(query_result))
+    ts = esta.TimeSeries.get_aggregate_time_series()
+    # Note to self, allow end_ts to also be null in the timequery
+    # we can then remove the start_time, end_time logic
+    # Alireza TODO: Replace with proper parsing for the start and end timestamp
+    entries = ts.find_entries(["analysis/confirmed_trip"],
+        time_query = estt.TimeQuery("data.start_ts", 0, sys.maxsize))
+    df = pd.json_normalize(list(entries))
+    # Alireza TODO: Make this be configurable, to support only the projection needed
+    # logging.warn("Before filtering, df columns are %s" % df.columns)
+    df = df[["user_id", "data.start_fmt_time", "data.end_fmt_time", "data.distance", "data.duration", "data.start_loc.coordinates", "data.end_loc.coordinates"]]
+    # logging.warn("After filtering, df columns are %s" % df.columns)
     if not df.empty:
         df['user_id'] = df['user_id'].apply(str)
+        df['trip_start_time_str'] = df['data.start_fmt_time']
+        df['trip_end_time_str'] = df['data.end_fmt_time']
+        df['start_coordinates'] = df['data.start_loc.coordinates']
+        df['end_coordinates'] = df['data.end_loc.coordinates']
         if 'data.start_place' in df.columns:
             df['data.start_place'] = df['data.start_place'].apply(str)
         if 'data.end_place' in df.columns:


### PR DESCRIPTION
This is a hack to get the dashboard to work.
It retrieves data using the timeseries interfaces and performs the projections using pandas locally.

It is *not* complete.

Notably:
- the projections are not the same as the original projections
- the projections do not take the dynamic config into account
- we still use `edb` for some calls - notably the ones to get the uuid table; we should add decorations to the timeseries to support them going forward

This is a partial fix for https://github.com/e-mission/op-admin-dashboard/issues/29