### PR TITLE
:lock: implement a basic CSP so that we can pass the WAVA scan

### DIFF
--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -25,6 +25,7 @@ if os.getenv('DASH_DEBUG_MODE', 'True').lower() == 'true':
 
 from utils.db_utils import query_uuids, query_confirmed_trips
 from utils.permissions import has_permission
+import flask_talisman as flt
 
 
 
@@ -222,7 +223,20 @@ def display_page(search):
 
     return home_page
 
+extra_csp_url = [
+    "https://raw.githubusercontent.com",
+    "https://*.tile.openstreetmap.org",
+    "https://cdn.jsdelivr.net",
+    "https://use.fontawesome.com",
+    "https://www.nrel.gov",
+    "data:",
+    "blob:"
+]
+csp = {
+       'default-src': ["'self'", "'unsafe-inline'"] + extra_csp_url
+      }
 
+flt.Talisman(server, content_security_policy=csp)
 
 if __name__ == "__main__":
     envPort = int(os.getenv('DASH_SERVER_PORT', '8050'))

--- a/pages/map.py
+++ b/pages/map.py
@@ -47,7 +47,7 @@ def create_lines_map(trips_group_by_user_id, user_id_list):
     fig.update_layout(
         showlegend=False,
         margin={'l': 0, 't': 30, 'b': 0, 'r': 0},
-        mapbox_style="stamen-terrain",
+        mapbox_style="open-street-map",
         mapbox_center_lon=start_lon,
         mapbox_center_lat=start_lat,
         mapbox_zoom=11,
@@ -93,7 +93,7 @@ def create_bubble_fig(data):
         )
         fig.update_layout(
             autosize=True,
-            mapbox_style='carto-positron',
+            mapbox_style='open-street-map',
             mapbox_center_lon=data['lon'][0],
             mapbox_center_lat=data['lat'][0],
             mapbox_zoom=11,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ pillow==9.5.0
 requests==2.28.2
 python-jose==3.3.0
 flask==2.2.5
+flask-talisman==1.0.0
 dash_auth==2.0.0


### PR DESCRIPTION
The CSP has multiple limitations:
- uses `unsafe-inline` - I tried the nonce and it didn't work
- puts everything into `default-src`

Filed issue to have the template fixed
https://github.com/NREL/nrel-app-template-bootstrap4/issues/16