### PR TITLE
Update Docker image tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM shankari/e-mission-server:master_2023-10-20--52-49
+FROM shankari/e-mission-server:master_2023-10-25--24-33
 
 ENV DASH_DEBUG_MODE True
 ENV SERVER_PORT 8050


### PR DESCRIPTION
Fixed base image for server after addressing latest vulnerabilities in [this PR](https://github.com/e-mission/e-mission-server/pull/943).

Updated docker image tag so dashboard can pull from the latest base server image.