### PR TITLE
📅 Datepicker: set initial range, use unambiguous date format, use `arrow`, dropdown for `timezone` option

### DIFF
--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -23,6 +23,7 @@ import logging
 if os.getenv('DASH_DEBUG_MODE', 'True').lower() == 'true':
     logging.basicConfig(level=logging.DEBUG)
 
+from utils.datetime_utils import iso_to_date_only
 from utils.db_utils import query_uuids, query_confirmed_trips, query_demographics
 from utils.permissions import has_permission
 import flask_talisman as flt
@@ -204,9 +205,7 @@ app.layout = make_layout
     Input('date-picker-timezone', 'value'),
 )
 def update_store_uuids(start_date, end_date, timezone):
-    # trim the time part, leaving only date as YYYY-MM-DD
-    start_date = start_date[:10] if start_date else None
-    end_date = end_date[:10] if end_date else None
+    (start_date, end_date) = iso_to_date_only(start_date, end_date)
     dff = query_uuids(start_date, end_date, timezone)
     records = dff.to_dict("records")
     store = {
@@ -236,14 +235,12 @@ def update_store_demographics(start_date, end_date, timezone):
 
 @app.callback(
     Output("store-trips", "data"),
-    Input('date-picker', 'start_date'),
-    Input('date-picker', 'end_date'),
+    Input('date-picker', 'start_date'), # these are ISO strings
+    Input('date-picker', 'end_date'), # these are ISO strings
     Input('date-picker-timezone', 'value'),
 )
 def update_store_trips(start_date, end_date, timezone):
-    # trim the time part, leaving only date as YYYY-MM-DD
-    start_date = start_date[:10] if start_date else None
-    end_date = end_date[:10] if end_date else None
+    (start_date, end_date) = iso_to_date_only(start_date, end_date)
     df = query_confirmed_trips(start_date, end_date, timezone)
     records = df.to_dict("records")
     # logging.debug("returning records %s" % records[0:2])

--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -130,7 +130,7 @@ content = html.Div([
     html.Div(
         dcc.DatePickerRange(
             id='date-picker',
-            display_format='D/M/Y',
+            display_format='D MMM Y',
             start_date=date.today() - timedelta(days=7),
             end_date=date.today(),
             min_date_allowed=date(2010, 1, 1),

--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -131,8 +131,8 @@ content = html.Div([
         dcc.DatePickerRange(
             id='date-picker',
             display_format='D/M/Y',
-            start_date_placeholder_text='D/M/Y',
-            end_date_placeholder_text='D/M/Y',
+            start_date=date.today() - timedelta(days=7),
+            end_date=date.today(),
             min_date_allowed=date(2010, 1, 1),
             max_date_allowed=date.today(),
             initial_visible_month=date.today(),
@@ -209,12 +209,8 @@ def update_store_uuids(start_date, end_date):
     Input('date-picker', 'end_date'),
 )
 def update_store_trips(start_date, end_date):
-    if not start_date or not end_date:
-        end_date_obj = date.today()
-        start_date_obj = end_date_obj - timedelta(days=7)
-    else:
-        start_date_obj = date.fromisoformat(start_date) 
-        end_date_obj = date.fromisoformat(end_date)
+    start_date_obj = date.fromisoformat(start_date)
+    end_date_obj = date.fromisoformat(end_date)
     df = query_confirmed_trips(start_date_obj, end_date_obj)
     records = df.to_dict("records")
     # logging.debug("returning records %s" % records[0:2])

--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -124,14 +124,14 @@ sidebar = html.Div(
     className="sidebar",
 )
 
-# according to docs, DatePickerRange will accept YYYY-MM-DD format
-today_date = arrow.now().format('YYYY-MM-DD')
-last_week_date = arrow.now().shift(days=-7).format('YYYY-MM-DD')
-tomorrow_date = arrow.now().shift(days=1).format('YYYY-MM-DD')
-
-content = html.Div([
-    # Global Date Picker
-    html.Div([
+# Global controls including date picker and timezone selector
+def make_controls():
+  # according to docs, DatePickerRange will accept YYYY-MM-DD format
+  today_date = arrow.now().format('YYYY-MM-DD')
+  last_week_date = arrow.now().shift(days=-7).format('YYYY-MM-DD')
+  tomorrow_date = arrow.now().shift(days=1).format('YYYY-MM-DD')
+  return html.Div([
+        # Global Date Picker
         dcc.DatePickerRange(
             id='date-picker',
             display_format='D MMM Y',
@@ -167,37 +167,34 @@ content = html.Div([
                'display': 'flex',
                'flex-direction': 'column',
                'align-items': 'end'}
-    ),
+    )
 
-    # Pages Content
-    dcc.Loading(
-        type='default',
-        fullscreen=True,
-        children=html.Div(dash.page_container, style={
-            "margin-left": "5rem",
-            "margin-right": "2rem",
-            "padding": "2rem 1rem",
-        })
-    ),
-])
-
-
-home_page = [
-    sidebar,
-    content,
-]
-
-app.layout = html.Div(
-    [
-        dcc.Location(id='url', refresh=False),
-        dcc.Store(id='store-trips', data={}),
-        dcc.Store(id='store-uuids', data={}),
-        dcc.Store(id='store-demographics', data= {}),
-        dcc.Store(id ='store-trajectories', data = {}),   
-        html.Div(id='page-content', children=home_page),
-    ]
+page_content = dcc.Loading(
+    type='default',
+    fullscreen=True,
+    children=html.Div(dash.page_container, style={
+        "margin-left": "5rem",
+        "margin-right": "2rem",
+        "padding": "2rem 1rem",
+    })
 )
 
+
+def make_home_page(): return [
+    sidebar,
+    html.Div([make_controls(), page_content])
+]
+
+
+def make_layout(): return html.Div([
+    dcc.Location(id='url', refresh=False),
+    dcc.Store(id='store-trips', data={}),
+    dcc.Store(id='store-uuids', data={}),
+    dcc.Store(id='store-demographics', data={}),
+    dcc.Store(id='store-trajectories', data={}),
+    html.Div(id='page-content', children=make_home_page()),
+])
+app.layout = make_layout
 
 # Load data stores
 @app.callback(
@@ -271,10 +268,10 @@ def display_page(search):
             return get_cognito_login_page('Unsuccessful authentication, try again.', 'red')
 
         if is_authenticated:
-            return home_page
+            return make_home_page()
         return get_cognito_login_page()
 
-    return home_page
+    return make_home_page()
 
 extra_csp_url = [
     "https://raw.githubusercontent.com",

--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -187,23 +187,6 @@ home_page = [
     content,
 ]
 
-@app.callback(
-    Output("store-demographics", "data"),
-    Input('date-picker', 'start_date'),
-    Input('date-picker', 'end_date'),
-    Input('date-picker-timezone', 'value'),
-)
-def update_store_demographics(start_date, end_date, timezone):
-    df = query_demographics()
-    records = {}
-    for key, dataframe in df.items():
-        records[key] = dataframe.to_dict("records")
-    store = {
-        "data": records,
-        "length": len(records),
-    }
-    return store
-
 app.layout = html.Div(
     [
         dcc.Location(id='url', refresh=False),
@@ -229,6 +212,24 @@ def update_store_uuids(start_date, end_date, timezone):
     end_date = end_date[:10] if end_date else None
     dff = query_uuids(start_date, end_date, timezone)
     records = dff.to_dict("records")
+    store = {
+        "data": records,
+        "length": len(records),
+    }
+    return store
+
+
+@app.callback(
+    Output("store-demographics", "data"),
+    Input('date-picker', 'start_date'),
+    Input('date-picker', 'end_date'),
+    Input('date-picker-timezone', 'value'),
+)
+def update_store_demographics(start_date, end_date, timezone):
+    df = query_demographics()
+    records = {}
+    for key, dataframe in df.items():
+        records[key] = dataframe.to_dict("records")
     store = {
         "data": records,
         "length": len(records),

--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -131,7 +131,7 @@ tomorrow_date = arrow.now().shift(days=1).format('YYYY-MM-DD')
 
 content = html.Div([
     # Global Date Picker
-    html.Div(
+    html.Div([
         dcc.DatePickerRange(
             id='date-picker',
             display_format='D MMM Y',
@@ -140,7 +140,33 @@ content = html.Div([
             min_date_allowed='2010-1-1',
             max_date_allowed=tomorrow_date,
             initial_visible_month=today_date,
-        ), style={'margin': '10px 10px 0 0', 'display': 'flex', 'justify-content': 'right'}
+        ),
+        html.Div([
+            html.Span('Query trips using: ', style={'margin-right': '10px'}),
+            dcc.Dropdown(
+                id='date-picker-timezone',
+                options=[
+                    {'label': 'UTC Time', 'value': 'utc'},
+                    {'label': 'My Local Timezone', 'value': 'local'},
+                    # {'label': 'Local Timezone of Trips', 'value': 'trips'},
+                ],
+                value='utc',
+                clearable=False,
+                searchable=False,
+                style={'width': '220px'},
+            ),
+        ],
+            style={'margin': '10px 10px 0 0',
+                   'display': 'flex',
+                   'justify-content': 'right',
+                   'align-items': 'center'},
+
+        ),
+    ],
+        style={'margin': '10px 10px 0 0',
+               'display': 'flex',
+               'flex-direction': 'column',
+               'align-items': 'end'}
     ),
 
     # Pages Content
@@ -165,8 +191,9 @@ home_page = [
     Output("store-demographics", "data"),
     Input('date-picker', 'start_date'),
     Input('date-picker', 'end_date'),
+    Input('date-picker-timezone', 'value'),
 )
-def update_store_demographics(start_date, end_date):
+def update_store_demographics(start_date, end_date, timezone):
     df = query_demographics()
     records = {}
     for key, dataframe in df.items():
@@ -192,14 +219,15 @@ app.layout = html.Div(
 # Load data stores
 @app.callback(
     Output("store-uuids", "data"),
-    Input('date-picker', 'start_date'), # these are ISO strings
-    Input('date-picker', 'end_date'), # these are ISO strings
+    Input('date-picker', 'start_date'),  # these are ISO strings
+    Input('date-picker', 'end_date'),  # these are ISO strings
+    Input('date-picker-timezone', 'value'),
 )
-def update_store_uuids(start_date, end_date):
+def update_store_uuids(start_date, end_date, timezone):
     # trim the time part, leaving only date as YYYY-MM-DD
     start_date = start_date[:10] if start_date else None
     end_date = end_date[:10] if end_date else None
-    dff = query_uuids(start_date, end_date)
+    dff = query_uuids(start_date, end_date, timezone)
     records = dff.to_dict("records")
     store = {
         "data": records,
@@ -212,12 +240,13 @@ def update_store_uuids(start_date, end_date):
     Output("store-trips", "data"),
     Input('date-picker', 'start_date'),
     Input('date-picker', 'end_date'),
+    Input('date-picker-timezone', 'value'),
 )
-def update_store_trips(start_date, end_date):
+def update_store_trips(start_date, end_date, timezone):
     # trim the time part, leaving only date as YYYY-MM-DD
     start_date = start_date[:10] if start_date else None
     end_date = end_date[:10] if end_date else None
-    df = query_confirmed_trips(start_date, end_date)
+    df = query_confirmed_trips(start_date, end_date, timezone)
     records = df.to_dict("records")
     # logging.debug("returning records %s" % records[0:2])
     store = {

--- a/pages/data.py
+++ b/pages/data.py
@@ -37,9 +37,9 @@ def clean_location_data(df):
         df['data.end_loc.coordinates'] = df['data.end_loc.coordinates'].apply(lambda x: f'({x[0]}, {x[1]})')
     return df
 
-def update_store_trajectories(start_date: str, end_date: str):
+def update_store_trajectories(start_date: str, end_date: str, tz: str):
     global store_trajectories
-    df = query_trajectories(start_date, end_date)
+    df = query_trajectories(start_date, end_date, tz)
     records = df.to_dict("records")
     store = {
         "data": records,
@@ -58,9 +58,9 @@ def update_store_trajectories(start_date: str, end_date: str):
     Input('store-trajectories', 'data'),
     Input('date-picker', 'start_date'),
     Input('date-picker', 'end_date'),
-
+    Input('date-picker-timezone', 'value'),
 )
-def render_content(tab, store_uuids, store_trips, store_demographics, store_trajectories, start_date, end_date):
+def render_content(tab, store_uuids, store_trips, store_demographics, store_trajectories, start_date, end_date, timezone):
     data, columns, has_perm = None, [], False
     if tab == 'tab-uuids-datatable':
         data = store_uuids["data"]
@@ -98,7 +98,7 @@ def render_content(tab, store_uuids, store_trips, store_demographics, store_traj
         #Here we query for trajectory data once "Trajectories" tab is selected
         start_date, end_date = start_date[:10], end_date[:10] # dates as YYYY-MM-DD
         if store_trajectories == {}:
-            store_trajectories = update_store_trajectories(start_date, end_date)
+            store_trajectories = update_store_trajectories(start_date, end_date, timezone)
         data = store_trajectories["data"]
         if data:
             columns = list(data[0].keys())

--- a/pages/data.py
+++ b/pages/data.py
@@ -97,12 +97,8 @@ def render_content(tab, store_uuids, store_trips, store_demographics, store_traj
     elif tab == 'tab-trajectories-datatable':
         # Currently store_trajectories data is loaded only when the respective tab is selected
         #Here we query for trajectory data once "Trajectories" tab is selected
-        if not start_date or not end_date:
-            end_date_obj = date.today()
-            start_date_obj = end_date_obj - timedelta(days=7)
-        else:
-            start_date_obj = date.fromisoformat(start_date) 
-            end_date_obj = date.fromisoformat(end_date)
+        start_date_obj = date.fromisoformat(start_date)
+        end_date_obj = date.fromisoformat(end_date)
         if store_trajectories == {}:
             store_trajectories = update_store_trajectories(start_date_obj,end_date_obj)
         data = store_trajectories["data"]

--- a/pages/data.py
+++ b/pages/data.py
@@ -4,7 +4,6 @@ Since the dcc.Location component is not in the layout when navigating to this pa
 The workaround is to check if the input value is None.
 """
 from dash import dcc, html, Input, Output, callback, register_page, dash_table
-from datetime import date, timedelta
 # Etc
 import logging
 import pandas as pd
@@ -38,10 +37,10 @@ def clean_location_data(df):
         df['data.end_loc.coordinates'] = df['data.end_loc.coordinates'].apply(lambda x: f'({x[0]}, {x[1]})')
     return df
 
-def update_store_trajectories(start_date_obj,end_date_obj):
+def update_store_trajectories(start_date: str, end_date: str):
     global store_trajectories
-    df = query_trajectories(start_date_obj,end_date_obj)
-    records = df.to_dict("records")   
+    df = query_trajectories(start_date, end_date)
+    records = df.to_dict("records")
     store = {
         "data": records,
         "length": len(records),
@@ -97,10 +96,9 @@ def render_content(tab, store_uuids, store_trips, store_demographics, store_traj
     elif tab == 'tab-trajectories-datatable':
         # Currently store_trajectories data is loaded only when the respective tab is selected
         #Here we query for trajectory data once "Trajectories" tab is selected
-        start_date_obj = date.fromisoformat(start_date)
-        end_date_obj = date.fromisoformat(end_date)
+        start_date, end_date = start_date[:10], end_date[:10] # dates as YYYY-MM-DD
         if store_trajectories == {}:
-            store_trajectories = update_store_trajectories(start_date_obj,end_date_obj)
+            store_trajectories = update_store_trajectories(start_date, end_date)
         data = store_trajectories["data"]
         if data:
             columns = list(data[0].keys())

--- a/pages/data.py
+++ b/pages/data.py
@@ -12,6 +12,7 @@ from dash.exceptions import PreventUpdate
 from utils import permissions as perm_utils
 from utils import db_utils
 from utils.db_utils import query_trajectories
+from utils.datetime_utils import iso_to_date_only
 register_page(__name__, path="/data")
 
 intro = """## Data"""
@@ -96,7 +97,7 @@ def render_content(tab, store_uuids, store_trips, store_demographics, store_traj
     elif tab == 'tab-trajectories-datatable':
         # Currently store_trajectories data is loaded only when the respective tab is selected
         #Here we query for trajectory data once "Trajectories" tab is selected
-        start_date, end_date = start_date[:10], end_date[:10] # dates as YYYY-MM-DD
+        (start_date, end_date) = iso_to_date_only(start_date, end_date)
         if store_trajectories == {}:
             store_trajectories = update_store_trajectories(start_date, end_date, timezone)
         data = store_trajectories["data"]

--- a/pages/home.py
+++ b/pages/home.py
@@ -18,6 +18,7 @@ import arrow
 import emission.core.get_database as edb
 
 from utils.permissions import has_permission
+from utils.datetime_utils import iso_to_date_only
 
 register_page(__name__, path="/")
 
@@ -175,13 +176,13 @@ def generate_plot_sign_up_trend(store_uuids):
 @callback(
     Output('fig-trips-trend', 'figure'),
     Input('store-trips', 'data'),
-    Input('date-picker', 'start_date'),
-    Input('date-picker', 'end_date'),
+    Input('date-picker', 'start_date'), # these are ISO strings
+    Input('date-picker', 'end_date'), # these are ISO strings
 )
 def generate_plot_trips_trend(store_trips, start_date, end_date):
     df = pd.DataFrame(store_trips.get("data"))
     trend_df = None
-    start_date, end_date = start_date[:10], end_date[:10] # dates as YYYY-MM-DD
+    (start_date, end_date) = iso_to_date_only(start_date, end_date)
     if not df.empty and has_permission('overview_trips_trend'):
         trend_df = compute_trips_trend(df, date_col = "trip_start_time_str")
     fig = generate_barplot(trend_df, x = 'date', y = 'count', title = f"Trips trend({start_date} to {end_date})")

--- a/pages/home.py
+++ b/pages/home.py
@@ -182,12 +182,8 @@ def generate_plot_sign_up_trend(store_uuids):
 def generate_plot_trips_trend(store_trips, start_date, end_date):
     df = pd.DataFrame(store_trips.get("data"))
     trend_df = None
-    if not start_date or not end_date:
-        end_date_obj = date.today()
-        start_date_obj = end_date_obj - timedelta(days=7)
-    else:
-        start_date_obj = date.fromisoformat(start_date) 
-        end_date_obj = date.fromisoformat(end_date)
+    start_date_obj = date.fromisoformat(start_date)
+    end_date_obj = date.fromisoformat(end_date)
     if not df.empty and has_permission('overview_trips_trend'):
         trend_df = compute_trips_trend(df, date_col = "trip_start_time_str")
     fig = generate_barplot(trend_df, x = 'date', y = 'count', title = f"Trips trend({start_date_obj} to {end_date_obj})")

--- a/pages/home.py
+++ b/pages/home.py
@@ -5,7 +5,6 @@ The workaround is to check if the input value is None.
 
 """
 from uuid import UUID
-from datetime import date, timedelta
 from dash import dcc, html, Input, Output, callback, register_page
 import dash_bootstrap_components as dbc
 
@@ -182,9 +181,8 @@ def generate_plot_sign_up_trend(store_uuids):
 def generate_plot_trips_trend(store_trips, start_date, end_date):
     df = pd.DataFrame(store_trips.get("data"))
     trend_df = None
-    start_date_obj = date.fromisoformat(start_date)
-    end_date_obj = date.fromisoformat(end_date)
+    start_date, end_date = start_date[:10], end_date[:10] # dates as YYYY-MM-DD
     if not df.empty and has_permission('overview_trips_trend'):
         trend_df = compute_trips_trend(df, date_col = "trip_start_time_str")
-    fig = generate_barplot(trend_df, x = 'date', y = 'count', title = f"Trips trend({start_date_obj} to {end_date_obj})")
+    fig = generate_barplot(trend_df, x = 'date', y = 'count', title = f"Trips trend({start_date} to {end_date})")
     return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-jose==3.3.0
 flask==2.2.5
 flask-talisman==1.0.0
 dash_auth==2.0.0
+arrow==1.3.0

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -1,0 +1,7 @@
+def iso_to_date_only(*iso_strs: str):
+    """
+    For each ISO date string in the input, returns only the date part in the format 'YYYY-MM-DD'
+    e.g. '2021-01-01T00:00:00.000Z' -> '2021-01-01'
+    """
+    return [iso_str[:10] if iso_str else None for iso_str in iso_strs]
+    

--- a/utils/datetime_utils.py
+++ b/utils/datetime_utils.py
@@ -1,7 +1,32 @@
+import arrow
+
+MAX_EPOCH_TIME = 2 ** 31 - 1
+
+
+def iso_range_to_ts_range(start_date: str, end_date: str, tz: str):
+    """
+    Returns a tuple of (start_ts, end_ts) as epoch timestamps, given start_date and end_date in
+    ISO format and the timezone mode in which the dates should be resolved to timestamps ('utc' or 'local')
+    """
+    start_ts, end_ts = None, MAX_EPOCH_TIME
+    if start_date is not None:
+        if tz == 'utc':
+            start_ts = arrow.get(start_date).timestamp()
+        elif tz == 'local':
+            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
+    if end_date is not None:
+        if tz == 'utc':
+            end_ts = arrow.get(end_date).replace(
+                hour=23, minute=59, second=59).timestamp()
+        elif tz == 'local':
+            end_ts = arrow.get(end_date, tzinfo='local').replace(
+                hour=23, minute=59, second=59).timestamp()
+    return (start_ts, end_ts)
+
+
 def iso_to_date_only(*iso_strs: str):
     """
     For each ISO date string in the input, returns only the date part in the format 'YYYY-MM-DD'
     e.g. '2021-01-01T00:00:00.000Z' -> '2021-01-01'
     """
     return [iso_str[:10] if iso_str else None for iso_str in iso_strs]
-    

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -31,11 +31,9 @@ def get_ts_range(start_date: str, end_date: str, tz: str):
             start_ts = arrow.get(start_date, tzinfo='local').timestamp()
     if end_date is not None:
         if tz == 'utc':
-            end_ts = arrow.get(end_date).replace(
-                hour=23, minute=59, second=59).timestamp()
+            end_ts = arrow.get(end_date).replace(hour=23, minute=59, second=59).timestamp()
         elif tz == 'local':
-            end_ts = arrow.get(end_date, tzinfo='local').replace(
-                hour=23, minute=59, second=59).timestamp()
+            end_ts = arrow.get(end_date, tzinfo='local').replace(hour=23, minute=59, second=59).timestamp()
     return (start_ts, end_ts)
 
 def query_uuids(start_date: str, end_date: str, tz: str):

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -2,8 +2,6 @@ import logging
 import arrow
 from uuid import UUID
 
-import arrow
-
 import pandas as pd
 import pymongo
 
@@ -15,26 +13,7 @@ import emission.core.wrapper.motionactivity as ecwm
 
 from utils import constants
 from utils import permissions as perm_utils
-
-MAX_EPOCH_TIME = 2 ** 31 - 1
-
-def get_ts_range(start_date: str, end_date: str, tz: str):
-    """
-    Returns a tuple of (start_ts, end_ts) as timestamps, given start_date and end_date in ISO format
-    and the timezone mode in which the dates should be resolved to timestamps ('utc' or 'local')
-    """
-    start_ts, end_ts = None, MAX_EPOCH_TIME
-    if start_date is not None:
-        if tz == 'utc':
-            start_ts = arrow.get(start_date).timestamp()
-        elif tz == 'local':
-            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
-    if end_date is not None:
-        if tz == 'utc':
-            end_ts = arrow.get(end_date).replace(hour=23, minute=59, second=59).timestamp()
-        elif tz == 'local':
-            end_ts = arrow.get(end_date, tzinfo='local').replace(hour=23, minute=59, second=59).timestamp()
-    return (start_ts, end_ts)
+from utils.datetime_utils import iso_range_to_ts_range
 
 def query_uuids(start_date: str, end_date: str, tz: str):
     # As of now, time filtering does not apply to UUIDs; we just query all of them.
@@ -74,7 +53,7 @@ def query_uuids(start_date: str, end_date: str, tz: str):
     return df
 
 def query_confirmed_trips(start_date: str, end_date: str, tz: str):
-    (start_ts, end_ts) = get_ts_range(start_date, end_date, tz)
+    (start_ts, end_ts) = iso_range_to_ts_range(start_date, end_date, tz)
     ts = esta.TimeSeries.get_aggregate_time_series()
     # Note to self, allow end_ts to also be null in the timequery
     # we can then remove the start_time, end_time logic
@@ -157,7 +136,7 @@ def query_demographics():
 
 def query_trajectories(start_date: str, end_date: str, tz: str):
     
-    (start_ts, end_ts) = get_ts_range(start_date, end_date, tz)
+    (start_ts, end_ts) = iso_range_to_ts_range(start_date, end_date, tz)
     ts = esta.TimeSeries.get_aggregate_time_series()
     entries = ts.find_entries(
         key_list=["analysis/recreated_location"],

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -18,6 +18,26 @@ from utils import permissions as perm_utils
 
 MAX_EPOCH_TIME = 2 ** 31 - 1
 
+def get_ts_range(start_date: str, end_date: str, tz: str):
+    """
+    Returns a tuple of (start_ts, end_ts) as timestamps, given start_date and end_date in ISO format
+    and the timezone mode in which the dates should be resolved to timestamps ('utc' or 'local')
+    """
+    start_ts, end_ts = None, MAX_EPOCH_TIME
+    if start_date is not None:
+        if tz == 'utc':
+            start_ts = arrow.get(start_date).timestamp()
+        elif tz == 'local':
+            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
+    if end_date is not None:
+        if tz == 'utc':
+            end_ts = arrow.get(end_date).replace(
+                hour=23, minute=59, second=59).timestamp()
+        elif tz == 'local':
+            end_ts = arrow.get(end_date, tzinfo='local').replace(
+                hour=23, minute=59, second=59).timestamp()
+    return (start_ts, end_ts)
+
 def query_uuids(start_date: str, end_date: str, tz: str):
     logging.debug("Querying the UUID DB for %s -> %s" % (start_date,end_date))
     query = {'update_ts': {'$exists': True}}
@@ -53,20 +73,7 @@ def query_uuids(start_date: str, end_date: str, tz: str):
     return df
 
 def query_confirmed_trips(start_date: str, end_date: str, tz: str):
-    start_ts, end_ts = None, MAX_EPOCH_TIME
-    if start_date is not None:
-        if tz == 'utc':
-            start_ts = arrow.get(start_date).timestamp()
-        elif tz == 'local':
-            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
-    if end_date is not None:
-        if tz == 'utc':
-            end_ts = arrow.get(end_date).replace(
-                hour=23, minute=59, second=59).timestamp()
-        elif tz == 'local':
-            end_ts = arrow.get(end_date, tzinfo='local').replace(
-                hour=23, minute=59, second=59).timestamp()
-
+    (start_ts, end_ts) = get_ts_range(start_date, end_date, tz)
     ts = esta.TimeSeries.get_aggregate_time_series()
     # Note to self, allow end_ts to also be null in the timequery
     # we can then remove the start_time, end_time logic
@@ -148,20 +155,8 @@ def query_demographics():
     return dataframes
 
 def query_trajectories(start_date: str, end_date: str, tz: str):
-    start_ts, end_ts = None, MAX_EPOCH_TIME
-    if start_date is not None:
-        if tz == 'utc':
-            start_ts = arrow.get(start_date).timestamp()
-        elif tz == 'local':
-            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
-    if end_date is not None:
-        if tz == 'utc':
-            end_ts = arrow.get(end_date).replace(
-                hour=23, minute=59, second=59).timestamp()
-        elif tz == 'local':
-            end_ts = arrow.get(end_date, tzinfo='local').replace(
-                hour=23, minute=59, second=59).timestamp()
-
+    
+    (start_ts, end_ts) = get_ts_range(start_date, end_date, tz)
     ts = esta.TimeSeries.get_aggregate_time_series()
     entries = ts.find_entries(
         key_list=["analysis/recreated_location"],

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -18,7 +18,7 @@ from utils import permissions as perm_utils
 
 MAX_EPOCH_TIME = 2 ** 31 - 1
 
-def query_uuids(start_date: str, end_date: str):
+def query_uuids(start_date: str, end_date: str, tz: str):
     logging.debug("Querying the UUID DB for %s -> %s" % (start_date,end_date))
     query = {'update_ts': {'$exists': True}}
     if start_date is not None:
@@ -52,12 +52,20 @@ def query_uuids(start_date: str, end_date: str):
         df.drop(columns=["uuid", "_id"], inplace=True)
     return df
 
-def query_confirmed_trips(start_date: str, end_date: str):
+def query_confirmed_trips(start_date: str, end_date: str, tz: str):
     start_ts, end_ts = None, MAX_EPOCH_TIME
     if start_date is not None:
-        start_ts = arrow.get(start_date).timestamp()
+        if tz == 'utc':
+            start_ts = arrow.get(start_date).timestamp()
+        elif tz == 'local':
+            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
     if end_date is not None:
-        end_ts = arrow.get(end_date).replace(hour=23, minute=59, second=59).timestamp()
+        if tz == 'utc':
+            end_ts = arrow.get(end_date).replace(
+                hour=23, minute=59, second=59).timestamp()
+        elif tz == 'local':
+            end_ts = arrow.get(end_date, tzinfo='local').replace(
+                hour=23, minute=59, second=59).timestamp()
 
     ts = esta.TimeSeries.get_aggregate_time_series()
     # Note to self, allow end_ts to also be null in the timequery
@@ -139,12 +147,20 @@ def query_demographics():
                     
     return dataframes
 
-def query_trajectories(start_date: str, end_date: str):
+def query_trajectories(start_date: str, end_date: str, tz: str):
     start_ts, end_ts = None, MAX_EPOCH_TIME
     if start_date is not None:
-      start_ts = arrow.get(start_date).timestamp()
+        if tz == 'utc':
+            start_ts = arrow.get(start_date).timestamp()
+        elif tz == 'local':
+            start_ts = arrow.get(start_date, tzinfo='local').timestamp()
     if end_date is not None:
-      end_ts = arrow.get(end_date).replace(hour=23, minute=59, second=59).timestamp()
+        if tz == 'utc':
+            end_ts = arrow.get(end_date).replace(
+                hour=23, minute=59, second=59).timestamp()
+        elif tz == 'local':
+            end_ts = arrow.get(end_date, tzinfo='local').replace(
+                hour=23, minute=59, second=59).timestamp()
 
     ts = esta.TimeSeries.get_aggregate_time_series()
     entries = ts.find_entries(

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -39,24 +39,27 @@ def get_ts_range(start_date: str, end_date: str, tz: str):
     return (start_ts, end_ts)
 
 def query_uuids(start_date: str, end_date: str, tz: str):
-    logging.debug("Querying the UUID DB for %s -> %s" % (start_date,end_date))
-    query = {'update_ts': {'$exists': True}}
-    if start_date is not None:
-        # have arrow create a datetime using start_date and time 00:00:00 in UTC
-        start_time = arrow.get(start_date).datetime
-        query['update_ts']['$gte'] = start_time
+    # As of now, time filtering does not apply to UUIDs; we just query all of them.
+    # Vestigial code commented out and left below for future reference
 
-    if end_date is not None:
-        # have arrow create a datetime using end_date and time 23:59:59 in UTC
-        end_time = arrow.get(end_date).replace(hour=23, minute=59, second=59).datetime
-        query['update_ts']['$lt'] = end_time
+    # logging.debug("Querying the UUID DB for %s -> %s" % (start_date,end_date))
+    # query = {'update_ts': {'$exists': True}}
+    # if start_date is not None:
+    #     # have arrow create a datetime using start_date and time 00:00:00 in UTC
+    #     start_time = arrow.get(start_date).datetime
+    #     query['update_ts']['$gte'] = start_time
+    # if end_date is not None:
+    #     # have arrow create a datetime using end_date and time 23:59:59 in UTC
+    #     end_time = arrow.get(end_date).replace(hour=23, minute=59, second=59).datetime
+    #     query['update_ts']['$lt'] = end_time
+    # projection = {
+    #     '_id': 0,
+    #     'user_id': '$uuid',
+    #     'user_token': '$user_email',
+    #     'update_ts': 1
+    # }
 
-    projection = {
-        '_id': 0,
-        'user_id': '$uuid',
-        'user_token': '$user_email',
-        'update_ts': 1
-    }
+    logging.debug("Querying the UUID DB for (no date range)")
 
     # This should actually use the profile DB instead of (or in addition to)
     # the UUID DB so that we can see the app version, os, manufacturer...


### PR DESCRIPTION
### set initial date range on datepicker
> On the initial load, the user has not selected a date and we fallback to only showing the last week of data. The datepicker should convey this information rather than showing blank initially.
> 
> This change sets initial start and end date values to the datepicker. As a result, we will no longer need extra checks for the initial condition when start date or end date have not been set yet. This simplifies the code in a few places.

### use unambiguous format on datepicker (D MMM Y)
> Consider "1/5/2024" – in the US this seems like January 5, while in most of the world it seems like May 1. Whether we did D/M/Y or M/D/Y, it'd probably cause some confusion since the project is used on an international scale.
> 
> So instead of just digits, the new format will be "5 Jan 2024". Unambiguous and still pretty concise.
> 