### PR TITLE
[Bug fix] Trips trend on Home not working

### DIFF
--- a/pages/home.py
+++ b/pages/home.py
@@ -64,7 +64,7 @@ def compute_sign_up_trend(uuid_df):
 
 
 def compute_trips_trend(trips_df, date_col):
-    trips_df[date_col] = pd.to_datetime(trips_df[date_col], utc=True, format='ISO8601')
+    trips_df[date_col] = pd.to_datetime(trips_df[date_col], utc=True)
     trips_df[date_col] = pd.DatetimeIndex(trips_df[date_col]).date
     res_df = (
         trips_df


### PR DESCRIPTION
### Overview
After our recent updates, the trip trends on the Home tab aren't working. The error occurs when the column data is converted to `datetime` with a specific format (ISO8601). 

#### [ Before ]
![Screenshot 2024-03-20 at 4 11 15 PM](https://github.com/e-mission/op-admin-dashboard/assets/47590587/717209eb-5563-4c40-b4c0-189f6bcda507)

#### [ After ]
![Screenshot 2024-03-20 at 4 12 30 PM](https://github.com/e-mission/op-admin-dashboard/assets/47590587/e01505e8-aef9-47db-9cbf-ae86db0379cc)
