### PR TITLE
Map - show map only when there is trip data

### DIFF
--- a/pages/map.py
+++ b/pages/map.py
@@ -222,7 +222,9 @@ layout = html.Div(
                 dcc.Dropdown(id='user-mode-dropdown', multi=True),
             ], style={'display': 'block'})
         ]),
-
+        dbc.Row(
+            html.H4("No trip data available for the selected date", id="no-trip-text")
+        ),
         dbc.Row(
             dcc.Graph(id="trip-map")
         ),
@@ -324,13 +326,19 @@ def process_trips_group(trips_group):
 
 @callback(
     Output('store-trips-map', 'data'),
+    Output('no-trip-text', 'style'),
+    Output('trip-map', 'style'),
     Input('store-trips', 'data'),
 )
 def store_trips_map_data(trips_data):
+    # if there is no trips_data for selected date, show 'no-trip-text'
+    if trips_data == None or 'length' not in trips_data or trips_data['length'] == 0:
+        return {'users_data_by_user_id': {}, 'users_data_by_user_mode': {}}, { 'display' : 'block', 'margin-top' : '40px' }, { 'display' : 'none' }
+    
     trips_group_by_user_id = get_trips_group_by_user_id(trips_data)
     users_data_by_user_id = process_trips_group(trips_group_by_user_id)
   
     trips_group_by_user_mode = get_trips_group_by_user_mode(trips_data)
     users_data_by_user_mode = process_trips_group(trips_group_by_user_mode)
-    
-    return {'users_data_by_user_id':users_data_by_user_id, 'users_data_by_user_mode':users_data_by_user_mode}
+
+    return {'users_data_by_user_id':users_data_by_user_id, 'users_data_by_user_mode':users_data_by_user_mode}, { 'display' : 'none' }, { 'display' : 'block' }

--- a/pages/map.py
+++ b/pages/map.py
@@ -332,7 +332,7 @@ def process_trips_group(trips_group):
 )
 def store_trips_map_data(trips_data):
     # if there is no trips_data for selected date, show 'no-trip-text'
-    if trips_data == None or 'length' not in trips_data or trips_data['length'] == 0:
+    if not trips_data['data']:
         return {'users_data_by_user_id': {}, 'users_data_by_user_mode': {}}, { 'display' : 'block', 'margin-top' : '40px' }, { 'display' : 'none' }
     
     trips_group_by_user_id = get_trips_group_by_user_id(trips_data)


### PR DESCRIPTION
### Overview
The current map page shows the map feature even though there is no trip data, which can appear as a bug to users. To prevent confusion, I added the 'no data' text when there is no trip data instead of displaying an empty map.

<br />

### screenshots
[ No trip data ]
![Screenshot 2024-03-26 at 11 45 35 AM](https://github.com/e-mission/op-admin-dashboard/assets/47590587/a7a1e6f5-2b9f-4034-8657-a5a0b7228737)

![Screenshot 2024-03-26 at 11 45 18 AM](https://github.com/e-mission/op-admin-dashboard/assets/47590587/928c3749-ee0e-4f19-a95e-81a83edd8b36)
