### PR TITLE
✨ Incorporate the sensed/inferred/BLE sensed primary modes and survey results

### DIFF
--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -311,12 +311,13 @@ def update_store_demographics(start_date, end_date, timezone, excluded_uuids):
 )
 def update_store_trips(start_date, end_date, timezone, excluded_uuids):
     (start_date, end_date) = iso_to_date_only(start_date, end_date)
-    df = query_confirmed_trips(start_date, end_date, timezone)
+    df, user_input_cols = query_confirmed_trips(start_date, end_date, timezone)
     records = df_to_filtered_records(df, 'user_id', excluded_uuids["data"])
     # logging.debug("returning records %s" % records[0:2])
     store = {
         "data": records,
         "length": len(records),
+        "userinputcols": user_input_cols
     }
     return store
 

--- a/pages/data.py
+++ b/pages/data.py
@@ -74,12 +74,16 @@ def render_content(tab, store_uuids, store_excluded_uuids, store_trips, store_de
         columns.update(
             col['label'] for col in perm_utils.get_allowed_named_trip_columns()
         )
+        columns.update(store_trips["userinputcols"])
         has_perm = perm_utils.has_permission('data_trips')
         df = pd.DataFrame(data)
         if df.empty or not has_perm:
             return None
 
+        logging.debug(f"Final list of retained cols {columns=}")
+        logging.debug(f"Before dropping, {df.columns=}")
         df = df.drop(columns=[col for col in df.columns if col not in columns])
+        logging.debug(f"After dropping, {df.columns=}")
         df = clean_location_data(df)
 
         trips_table = populate_datatable(df,'trips-table')

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -6,9 +6,6 @@ REQUIRED_NAMED_COLS = [
 ]
 
 MULTILABEL_NAMED_COLS = [
-    {'label': 'mode_confirm', 'path': 'data.user_input.mode_confirm'},
-    {'label': 'purpose_confirm', 'path': 'data.user_input.purpose_confirm'},
-    {'label': 'replaced_mode', 'path': 'data.user_input.replaced_mode'},
 ]
 
 VALID_TRIP_COLS = [
@@ -27,6 +24,9 @@ VALID_TRIP_COLS = [
     "data.primary_sensed_mode",
     "data.primary_predicted_mode",
     "data.primary_ble_sensed_mode",
+    "mode_confirm",
+    "purpose_confirm",
+    "replaced_mode",
     "user_id"
 ]
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -24,6 +24,9 @@ VALID_TRIP_COLS = [
     "data.distance_meters",
     "data.start_loc.coordinates",
     "data.end_loc.coordinates",
+    "data.primary_sensed_mode",
+    "data.primary_predicted_mode",
+    "data.primary_ble_sensed_mode",
     "user_id"
 ]
 
@@ -31,6 +34,8 @@ BINARY_TRIP_COLS = [
     'user_id',
     'data.start_place',
     'data.end_place',
+    "cleaned_section_summary",
+    "inferred_section_summary",
 ]
 
 valid_uuids_columns = [

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -24,9 +24,6 @@ VALID_TRIP_COLS = [
     "data.primary_sensed_mode",
     "data.primary_predicted_mode",
     "data.primary_ble_sensed_mode",
-    "mode_confirm",
-    "purpose_confirm",
-    "replaced_mode",
     "user_id"
 ]
 

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -79,10 +79,7 @@ def query_confirmed_trips(start_date: str, end_date: str, tz: str):
         # Since we use `get_data_df` instead of `pd.json_normalize`,
         # we lose the "data" prefix on the fields and they are only flattened one level
         # Here, we restore the prefix for the VALID_TRIP_COLS from constants.py
-        # for backwards compatibility. We do this for all columns EXCEPT:
-        # 1. the coordinates, which we will have to pull out from the geojson anyway
-        # 2. the user_id, which doesn't need to be copied
-        # 3. the primary modes, which have not yet been populated
+        # for backwards compatibility. We do this for all columns since columns which don't exist are ignored by the rename command.
         rename_cols = constants.VALID_TRIP_COLS
         # the mapping is `{distance: data.distance, duration: data.duration} etc
         rename_mapping = dict(zip([c.replace("data.", "") for c in rename_cols], rename_cols))
@@ -94,7 +91,7 @@ def query_confirmed_trips(start_date: str, end_date: str, tz: str):
         df['data.start_loc.coordinates'] = df['start_loc'].apply(lambda g: g["coordinates"])
         df['data.end_loc.coordinates'] = df['end_loc'].apply(lambda g: g["coordinates"])
 
-        # Add sensed, inferred and ble summaries. Note that we do this
+        # Add primary modes from the sensed, inferred and ble summaries. Note that we do this
         # **before** filtering the `all_trip_columns` because the
         # *_section_summary columns are not currently valid
         get_max_mode_from_summary = lambda md: max(md["distance"], key=md["distance"].get) if len(md["distance"]) > 0 else "INVALID"

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -82,7 +82,7 @@ def query_confirmed_trips(start_date: str, end_date: str, tz: str):
         # 1. the coordinates, which we will have to pull out from the geojson anyway
         # 2. the user_id, which doesn't need to be copied
         # 3. the primary modes, which have not yet been populated
-        rename_cols = [c for c in constants.VALID_TRIP_COLS if c is not "user_id"]
+        rename_cols = constants.VALID_TRIP_COLS
         # the mapping is `{distance: data.distance, duration: data.duration} etc
         rename_mapping = dict(zip([c.replace("data.", "") for c in rename_cols], rename_cols))
         logging.debug("Rename mapping is %s" % rename_mapping)
@@ -103,6 +103,10 @@ def query_confirmed_trips(start_date: str, end_date: str, tz: str):
             df["data.primary_ble_sensed_mode"] = df.ble_sensed_summary.apply(get_max_mode_from_summary)
         else:
             logging.debug("No BLE support found, not fleet version, ignoring...")
+
+        # Expand the user inputs
+        df = pd.concat([df, pd.json_normalize(df.user_input)], axis='columns')
+
         columns = [col for col in perm_utils.get_all_trip_columns() if col in df.columns]
         df = df[columns]
         # logging.debug("After getting all columns, they are %s" % df.columns)

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -77,6 +77,8 @@ def get_all_trip_columns():
 
     columns.update(get_required_columns())
     # logging.debug("get_all_trip_columns: curr set is %s" % columns)
+    columns.update(permissions.get('additional_trip_columns', []))
+    logging.debug("get_all_trip_columns: after additional columns, curr set is %s" % columns)
     return columns
 
 
@@ -84,6 +86,9 @@ def get_allowed_trip_columns():
     columns = set(constants.VALID_TRIP_COLS)
     for column in permissions.get("data_trips_columns_exclude", []):
         columns.discard(column)
+    for column in permissions.get("additional_trip_columns", []):
+        columns.add(column)
+    logging.debug("allowed trip columns are %s" % columns)
     return columns
 
 


### PR DESCRIPTION
…rip table

My original thought was that this would be a simple 2-3 line change where I would enable the cleaned/inferred mode summaries in the set of valid columns.

However, while actually implementing it, I ran into several issues:
1. we display the primary sensed mode in the public dashboard, so we can't just display the summary, we have to extract the primary mode

2. I then switched to using the primary mode computation from the public dashboard, only to discover that it needs the summary as an object.  However, the previous implementation of this code used `pd.json_normalize`, which resulted in columns like

```
       'data.inferred_section_summary.distance.TRAIN',
       'data.inferred_section_summary.duration.TRAIN',
       'data.inferred_section_summary.count.TRAIN',
       'data.inferred_section_summary.distance.TRAM',
       'data.inferred_section_summary.duration.TRAM',
       'data.inferred_section_summary.count.TRAM'],
```

and not the expected

```
'inferred_section_summary': {'distance': {'CAR': ...}}
```

3. To workaround this, I switched to using `get_data_df`, as we do in the public dashboard. This gave us the correct objects *but* changed the names of the columns so that they no longer had the `data` prefix. This could lead to backwards compat issues with the excluded columns from the configs.

```
      "data_trips_columns_exclude": ["data.start_loc.coordinates", "data.end_loc.coordinates"],
```

So the current solution is:
- use data_df
- rename the columns using a dynamically generated mapper for backwards compat
- find the primary mode in the summaries
- enable the primary modes as valid columns

The rest of the code is untouched

Testing done:
See screenshots in PR

Note further that the list of valid cols has `data.start_local_dt` and `data.end_local_dt` however, the actual columns are `end_local_dt_day` etc so are not renamed. I double checked, and I am not sure how this ever worked - `pd.json_normalize` also returns

```
data.end_local_dt.year
data.end_local_dt.month
data.end_local_dt.day
data.end_local_dt.hour
```

and I have verified that the columns don't show up on staging

@JGreenlee @louisg1337 here's another area to unify data handling.

Note finally that I also tried enabling the full summary objects, but they made the table very long and fairly confusing, so I removed them again. They can be enabled by editing `utils/constants.py` again