### PR TITLE
UUE Temp Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ assets/qrcodes
 data/tokens.csv
 config.py
 docker-compose-dev.yml
+*.bak

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
       DASH_DEBUG_MODE: "True"
       DASH_SILENCE_ROUTES_LOGGING: "False"
       DASH_SERVER_PORT: 8050
-      DB_HOST: mongodb://db/DB_NAME
+      DB_HOST: mongodb://db/openpath_prod_ca_ebike
       WEB_SERVER_HOST: 0.0.0.0
       SERVER_BRANCH: master
       CONFIG_PATH: "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
       DASH_DEBUG_MODE: "True"
       DASH_SILENCE_ROUTES_LOGGING: "False"
       DASH_SERVER_PORT: 8050
-      DB_HOST: mongodb://db/openpath_prod_ca_ebike
+      DB_HOST: mongodb://db/DB_NAME
       WEB_SERVER_HOST: 0.0.0.0
       SERVER_BRANCH: master
       CONFIG_PATH: "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/"


### PR DESCRIPTION
## Changes

### 1. Admin Dashboard Toggle for Key List
A toggle has been added to the "Trajectories" tab in the admin dashboard. This will allow administrators to switch between viewing "Analysis/Recreated Location" data and raw "Background/Location" data. The toggle is initially hidden and only visible when the "Trajectories" tab is active.


### Purpose
This change is a high-priority temporary measure to restore functionality to UUE's admin dashboard. It enables them to access raw trajectory data, ensuring they remain unblocked while a more permanent solution is being worked on.

### Testing
- Verified that the toggle switch properly switches between the two data views.