### PR TITLE
Update load_mongodump.sh script to update the STUDY_CONFIG from database name while loading mongo dump

### DIFF
--- a/docker/load_mongodump.sh
+++ b/docker/load_mongodump.sh
@@ -53,6 +53,10 @@ echo "Database Name: $DB_NAME"
 DB_HOST="mongodb://db/$DB_NAME"
 sed -i.bak "s|DB_HOST:.*|DB_HOST: $DB_HOST|" "$CONFIG_FILE"
 
+# Update the docker-compose configuration file with the actual STUDY_CONFIG
+STUDY_CONFIG=$(echo "$DB_NAME" | sed -E 's/openpath_prod_(.*)$/\1/' | tr '_' '-')
+sed -i.bak "s|STUDY_CONFIG:.*|STUDY_CONFIG: \"$STUDY_CONFIG\"|" "$CONFIG_FILE"
+
 echo "Updated docker-compose file:"
 cat "$CONFIG_FILE"
 


### PR DESCRIPTION
- Checks for the database name starting as openpath_prod_***. For example, if the database name is "openpath_prod_abc_def_ghi" it identifies the program/study name as abc-def-ghi and sets the STUDY_CONFIG : "abc-def-ghi"
- Update load_mongodump.sh script to update the STUDY_CONFIG from the database name into docker-compose-dev.yml file after running the load_mongodump.sh script.

Testing Scenario:

Dataset used: `openpath_prod_ca_ebike_may_29.tar.gz`

Changes in the `docker-compose-dev.yml` file:

```
ashrest2-41625s:op-admin-dashboard ashrest2$ git diff docker-compose-dev.yml
diff --git a/docker-compose-dev.yml b/docker-compose-dev.yml
index 5660b66..987e416 100644
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,11 +14,11 @@ services:
       DASH_DEBUG_MODE: "True"
       DASH_SILENCE_ROUTES_LOGGING: "False"
       DASH_SERVER_PORT: 8050
-      DB_HOST: mongodb://db/DB_NAME
+      DB_HOST: mongodb://db/openpath_prod_ca_ebike
       WEB_SERVER_HOST: 0.0.0.0
       SERVER_BRANCH: master
       CONFIG_PATH: "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/"
-      STUDY_CONFIG: "stage-program"
+      STUDY_CONFIG: "ca-ebike"
       AUTH_TYPE: "basic" # the other option is cognito
       REACT_VERSION: "18.2.0"
     networks:
ashrest2-41625s:op-admin-dashboard ashrest2$
```

Execution detail of the script:
<details><summary>Details</summary>
<p>

```
ashrest2-41625s:op-admin-dashboard ashrest2$ bash docker/load_mongodump.sh openpath_prod_ca_ebike_may_29.tar.gz 
Script Directory: docker
Configuration File Path: docker/../docker-compose-dev.yml
MongoDump File Path: openpath_prod_ca_ebike_may_29.tar.gz
Configuration file details:
-rw-r--r--@ 1 ashrest2  NREL_NT\Domain Users  1256 Oct  2 16:02 docker/../docker-compose-dev.yml
openpath_prod_ca_ebike
Database Name: openpath_prod_ca_ebike
Updated docker-compose file:
# docker-compose.yml
version: "3"
services:
  dashboard:
    build:
      context: .
      dockerfile: docker/Dockerfile
      args:
        SERVER_IMAGE_TAG: ${SERVER_IMAGE_TAG}
    image: e-mission/opdash:0.0.1
    ports:
      - "8050:8050"
    environment:
      DASH_DEBUG_MODE: "True"
      DASH_SILENCE_ROUTES_LOGGING: "False"
      DASH_SERVER_PORT: 8050
      DB_HOST: mongodb://db/openpath_prod_ca_ebike
      WEB_SERVER_HOST: 0.0.0.0
      SERVER_BRANCH: master
      CONFIG_PATH: "https://raw.githubusercontent.com/e-mission/nrel-openpath-deploy-configs/main/configs/"
      STUDY_CONFIG: "ca-ebike"
      AUTH_TYPE: "basic" # the other option is cognito
      REACT_VERSION: "18.2.0"
    networks:
       - emission
    volumes:
      - ./pages:/usr/src/app/pages
      - ./utils:/usr/src/app/utils
      - ./app.py:/usr/src/app/app.py
      - ./app_sidebar_collapsible.py:/usr/src/app/app_sidebar_collapsible.py
    deploy:
      restart_policy:
          condition: on-failure
  db:
    image: mongo:4.4.0
    deploy:
      replicas: 1
      restart_policy:
        condition: on-failure
    volumes:
      - mongo-data:/data/db
    networks:
       - emission
    ports:
      - "27017:27017"

networks:
  emission:

volumes:
  mongo-data:
Copying file to Docker container
Successfully copied 267MB to op-admin-dashboard-db-1:/tmp
Clearing existing database
MongoDB shell version v4.4.0
connecting to: mongodb://127.0.0.1:27017/openpath_prod_ca_ebike?compressors=disabled&gssapiServiceName=mongodb
Implicit session: session { "id" : UUID("d5e197ee-1862-4ef7-871f-19a1397d2e4f") }
MongoDB server version: 4.4.0
{ "dropped" : "openpath_prod_ca_ebike", "ok" : 1 }
Restoring the dump from openpath_prod_ca_ebike_may_29.tar.gz to database openpath_prod_ca_ebike
dump/
dump/openpath_prod_ca_ebike/
dump/openpath_prod_ca_ebike/Stage_pipeline_state.metadata.json
dump/openpath_prod_ca_ebike/Stage_usercache.metadata.json
dump/openpath_prod_ca_ebike/Stage_analysis_timeseries.metadata.json
dump/openpath_prod_ca_ebike/Stage_push_token_mapping.metadata.json
dump/openpath_prod_ca_ebike/Stage_updateable_models.metadata.json
dump/openpath_prod_ca_ebike/Stage_timeseries_error.metadata.json
dump/openpath_prod_ca_ebike/Stage_uuids.metadata.json
dump/openpath_prod_ca_ebike/Stage_timeseries.metadata.json
dump/openpath_prod_ca_ebike/Stage_Tokens.metadata.json
dump/openpath_prod_ca_ebike/Stage_Profiles.metadata.json
dump/openpath_prod_ca_ebike/Stage_analysis_timeseries.bson
dump/openpath_prod_ca_ebike/Stage_Tokens.bson
dump/openpath_prod_ca_ebike/Stage_usercache.bson
dump/openpath_prod_ca_ebike/Stage_timeseries.bson
dump/openpath_prod_ca_ebike/Stage_updateable_models.bson
dump/openpath_prod_ca_ebike/Stage_timeseries_error.bson
dump/openpath_prod_ca_ebike/Stage_pipeline_state.bson
dump/openpath_prod_ca_ebike/Stage_Profiles.bson
dump/openpath_prod_ca_ebike/Stage_uuids.bson
dump/openpath_prod_ca_ebike/Stage_push_token_mapping.bson
2024-10-02T23:12:24.566+0000    The --db and --collection flags are deprecated for this use-case; please use --nsInclude instead, i.e. with --nsInclude=${DATABASE}.${COLLECTION}
2024-10-02T23:12:24.566+0000    building a list of collections to restore from dump/openpath_prod_ca_ebike dir
2024-10-02T23:12:24.567+0000    reading metadata for openpath_prod_ca_ebike.Stage_timeseries from dump/openpath_prod_ca_ebike/Stage_timeseries.metadata.json
2024-10-02T23:12:24.567+0000    reading metadata for openpath_prod_ca_ebike.Stage_analysis_timeseries from dump/openpath_prod_ca_ebike/Stage_analysis_timeseries.metadata.json
2024-10-02T23:12:24.567+0000    reading metadata for openpath_prod_ca_ebike.Stage_updateable_models from dump/openpath_prod_ca_ebike/Stage_updateable_models.metadata.json
2024-10-02T23:12:24.568+0000    reading metadata for openpath_prod_ca_ebike.Stage_usercache from dump/openpath_prod_ca_ebike/Stage_usercache.metadata.json
2024-10-02T23:12:24.857+0000    restoring openpath_prod_ca_ebike.Stage_updateable_models from dump/openpath_prod_ca_ebike/Stage_updateable_models.bson
2024-10-02T23:12:24.859+0000    restoring openpath_prod_ca_ebike.Stage_timeseries from dump/openpath_prod_ca_ebike/Stage_timeseries.bson
2024-10-02T23:12:24.861+0000    restoring openpath_prod_ca_ebike.Stage_analysis_timeseries from dump/openpath_prod_ca_ebike/Stage_analysis_timeseries.bson
2024-10-02T23:12:24.863+0000    restoring openpath_prod_ca_ebike.Stage_usercache from dump/openpath_prod_ca_ebike/Stage_usercache.bson
2024-10-02T23:12:25.452+0000    restoring indexes for collection openpath_prod_ca_ebike.Stage_updateable_models from metadata
2024-10-02T23:12:25.486+0000    finished restoring openpath_prod_ca_ebike.Stage_updateable_models (3 documents, 0 failures)
2024-10-02T23:12:25.486+0000    reading metadata for openpath_prod_ca_ebike.Stage_Tokens from dump/openpath_prod_ca_ebike/Stage_Tokens.metadata.json
2024-10-02T23:12:25.494+0000    restoring openpath_prod_ca_ebike.Stage_Tokens from dump/openpath_prod_ca_ebike/Stage_Tokens.bson
2024-10-02T23:12:25.612+0000    restoring indexes for collection openpath_prod_ca_ebike.Stage_usercache from metadata
2024-10-02T23:12:26.100+0000    finished restoring openpath_prod_ca_ebike.Stage_usercache (128135 documents, 0 failures)
2024-10-02T23:12:26.100+0000    reading metadata for openpath_prod_ca_ebike.Stage_timeseries_error from dump/openpath_prod_ca_ebike/Stage_timeseries_error.metadata.json
2024-10-02T23:12:26.105+0000    restoring openpath_prod_ca_ebike.Stage_timeseries_error from dump/openpath_prod_ca_ebike/Stage_timeseries_error.bson
2024-10-02T23:12:26.107+0000    no indexes to restore
2024-10-02T23:12:26.107+0000    finished restoring openpath_prod_ca_ebike.Stage_timeseries_error (489 documents, 0 failures)
2024-10-02T23:12:26.107+0000    reading metadata for openpath_prod_ca_ebike.Stage_pipeline_state from dump/openpath_prod_ca_ebike/Stage_pipeline_state.metadata.json
2024-10-02T23:12:26.114+0000    restoring openpath_prod_ca_ebike.Stage_pipeline_state from dump/openpath_prod_ca_ebike/Stage_pipeline_state.bson
2024-10-02T23:12:26.116+0000    no indexes to restore
2024-10-02T23:12:26.116+0000    finished restoring openpath_prod_ca_ebike.Stage_pipeline_state (178 documents, 0 failures)
2024-10-02T23:12:26.116+0000    reading metadata for openpath_prod_ca_ebike.Stage_Profiles from dump/openpath_prod_ca_ebike/Stage_Profiles.metadata.json
2024-10-02T23:12:26.122+0000    restoring openpath_prod_ca_ebike.Stage_Profiles from dump/openpath_prod_ca_ebike/Stage_Profiles.bson
2024-10-02T23:12:26.123+0000    no indexes to restore
2024-10-02T23:12:26.123+0000    finished restoring openpath_prod_ca_ebike.Stage_Profiles (13 documents, 0 failures)
2024-10-02T23:12:26.123+0000    reading metadata for openpath_prod_ca_ebike.Stage_push_token_mapping from dump/openpath_prod_ca_ebike/Stage_push_token_mapping.metadata.json
2024-10-02T23:12:26.127+0000    restoring openpath_prod_ca_ebike.Stage_push_token_mapping from dump/openpath_prod_ca_ebike/Stage_push_token_mapping.bson
2024-10-02T23:12:26.128+0000    no indexes to restore
2024-10-02T23:12:26.128+0000    finished restoring openpath_prod_ca_ebike.Stage_push_token_mapping (10 documents, 0 failures)
2024-10-02T23:12:26.128+0000    reading metadata for openpath_prod_ca_ebike.Stage_uuids from dump/openpath_prod_ca_ebike/Stage_uuids.metadata.json
2024-10-02T23:12:26.135+0000    restoring openpath_prod_ca_ebike.Stage_uuids from dump/openpath_prod_ca_ebike/Stage_uuids.bson
2024-10-02T23:12:26.136+0000    no indexes to restore
2024-10-02T23:12:26.136+0000    finished restoring openpath_prod_ca_ebike.Stage_uuids (13 documents, 0 failures)
2024-10-02T23:12:26.231+0000    no indexes to restore
2024-10-02T23:12:26.231+0000    finished restoring openpath_prod_ca_ebike.Stage_Tokens (200050 documents, 0 failures)
2024-10-02T23:12:27.567+0000    [###.....................]           openpath_prod_ca_ebike.Stage_timeseries  312MB/2.19GB  (13.9%)
2024-10-02T23:12:27.567+0000    [##################......]  openpath_prod_ca_ebike.Stage_analysis_timeseries   445MB/564MB  (78.9%)
2024-10-02T23:12:27.567+0000
2024-10-02T23:12:28.215+0000    [########################]  openpath_prod_ca_ebike.Stage_analysis_timeseries  564MB/564MB  (100.0%)
2024-10-02T23:12:28.215+0000    restoring indexes for collection openpath_prod_ca_ebike.Stage_analysis_timeseries from metadata
2024-10-02T23:12:30.567+0000    [#######.................]  openpath_prod_ca_ebike.Stage_timeseries  723MB/2.19GB  (32.3%)
2024-10-02T23:12:33.570+0000    [############............]  openpath_prod_ca_ebike.Stage_timeseries  1.12GB/2.19GB  (51.4%)
2024-10-02T23:12:36.567+0000    [################........]  openpath_prod_ca_ebike.Stage_timeseries  1.53GB/2.19GB  (69.9%)
2024-10-02T23:12:37.222+0000    finished restoring openpath_prod_ca_ebike.Stage_analysis_timeseries (444656 documents, 0 failures)
2024-10-02T23:12:39.567+0000    [#####################...]  openpath_prod_ca_ebike.Stage_timeseries  1.95GB/2.19GB  (89.2%)
2024-10-02T23:12:41.236+0000    [########################]  openpath_prod_ca_ebike.Stage_timeseries  2.19GB/2.19GB  (100.0%)
2024-10-02T23:12:41.236+0000    restoring indexes for collection openpath_prod_ca_ebike.Stage_timeseries from metadata
2024-10-02T23:12:54.483+0000    finished restoring openpath_prod_ca_ebike.Stage_timeseries (3286865 documents, 0 failures)
2024-10-02T23:12:54.483+0000    4060412 document(s) restored successfully. 0 document(s) failed to restore.
Database restore complete.
ashrest2-41625s:op-admin-dashboard ashrest2$ 
```

</p>
</details> 

Launched the site [http://0.0.0.0:8050](http://0.0.0.0:8050) with proper credential. Looks good.
