### PR TITLE
 Integrate New User Statistics into Profile Retrieval

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -35,7 +35,7 @@ BINARY_TRIP_COLS = [
     "inferred_section_summary",
 ]
 
-valid_uuids_columns = [
+VALID_UUIDS_COLS = [
     'user_token',
     'user_id',
     'update_ts',

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -93,7 +93,7 @@ def get_allowed_trip_columns():
 
 
 def get_uuids_columns():
-    columns = set(constants.valid_uuids_columns)
+    columns = set(constants.VALID_UUIDS_COLS)
     for column in permissions.get("data_uuids_columns_exclude", []):
         columns.discard(column)
     return columns


### PR DESCRIPTION
## Overview

Enhances the user profile data retrieval process by incorporating newly stored statistics (`pipeline_range`, `total_trips`, `labeled_trips`, and `last_call`) into the existing `with` block. These statistics are now seamlessly integrated into the `user` dictionary, providing a more comprehensive set of user metrics for further analysis and dashboard visualization.

## Changes Made

### 1. **Enhanced Profile Data Retrieval**

- **Existing Functionality**:
  - The `with` block previously retrieved basic profile information such as `platform`, `manufacturer`, `app_version`, `os_version`, and `phone_lang` from the database and assigned them to the `user` dictionary.

- **New Enhancements**:
  - **Pipeline Range**:
    - Retrieved `pipeline_range` data, including `start_ts` and `end_ts`, to understand the timeframe of the user's activity pipeline.
  - **Trip Counts**:
    - Extracted `total_trips` and `labeled_trips` to provide insights into the user's trip data and the extent of trip labeling.
  - **Last API Call Timestamp**:
    - Obtained `last_call` to track the most recent API interaction by the user.
  - **Optional Formatting**:
    - Included a formatted version of the `last_call` timestamp for better readability in reports and dashboards.

### 2. **Updated `with` Block Structure**

- **Integration of New Statistics**:
  - The `with` block now not only fetches and assigns basic profile attributes but also retrieves and assigns the newly stored statistics from the database.
  
  Awaiting https://github.com/e-mission/e-mission-server/pull/993
  