### PR TITLE
improve batch loading of UUIDs stats

### DIFF
--- a/app_sidebar_collapsible.py
+++ b/app_sidebar_collapsible.py
@@ -14,7 +14,7 @@ import arrow
 
 import dash
 import dash_bootstrap_components as dbc
-from dash import Input, Output, dcc, html, Dash
+from dash import Input, Output, dcc, html, Dash, DiskcacheManager
 import dash_auth
 import logging
 import base64
@@ -42,10 +42,17 @@ elif auth_type == 'basic':
         'hello': 'world'
     }
 
+# diskcache manager; required for 'background' callbacks
+# https: // dash.plotly.com/background-callbacks
+import diskcache
+cache = diskcache.Cache("./cache")
+background_callback_manager = DiskcacheManager(cache)
+
 app = Dash(
     external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.FONT_AWESOME],
     suppress_callback_exceptions=True,
     use_pages=True,
+    background_callback_manager=background_callback_manager
 )
 server = app.server  # expose server variable for Procfile
 

--- a/pages/data.py
+++ b/pages/data.py
@@ -31,7 +31,6 @@ layout = html.Div(
         ]),
         html.Div(id='tabs-content'),
         dcc.Store(id='selected-tab', data='tab-uuids-datatable'),  # Store to hold selected tab
-        dcc.Store(id='store-uuids', data=[]),  # Store to hold the original UUIDs data
         dcc.Store(id='loaded-uuids-stats', data=[]),
         dcc.Store(id='all-uuids-stats-loaded', data=False),
         dcc.Store(id='uuids-page-current', data=0),  # Store to track current page for UUIDs DataTable

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,8 @@ flask-talisman==1.0.0
 dash_auth==2.0.0
 arrow==1.3.0
 dash-leaflet==1.0.7
+# dash[diskcache] dependencies
+# from https://github.com/plotly/dash/blob/dev/requirements/diskcache.txt
+diskcache>=5.2.1
+multiprocess>=0.70.12
+psutil>=5.8.0


### PR DESCRIPTION
https://dash.plotly.com/background-callbacks#using-set_props-within-a-callback

Implements a 'background' callback to improve the batching of add_user_stats. This avoids relying on a dcc.Interval with a fixed time between batches

The new callback, which has background=True, continues running continuously on the server until all of the chunks have been processed. At the end of each chunk it calls set_props, which sends an update to the UI with the latest data for 'store-loaded-uuids'

This should speed things up further and prevent any glitches caused by the fixed interval