### PR TITLE
Added new fields based on recent profile stat additions

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -53,6 +53,8 @@ VALID_UUIDS_COLS = [
     'last_phone_data_ts',
     'last_sync_ts',
     'last_diary_fetch_ts',
+    'create_ts',
+    'update_ts',
 ]
 
 BINARY_DEMOGRAPHICS_COLS = [

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -49,6 +49,10 @@ VALID_UUIDS_COLS = [
     'app_version',
     'os_version',
     'phone_lang',
+    'last_location_ts',
+    'last_phone_data_ts',
+    'last_sync_ts',
+    'last_diary_fetch_ts',
 ]
 
 BINARY_DEMOGRAPHICS_COLS = [

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -448,6 +448,11 @@ def add_user_stats(user_data, batch_size=5):
                 user['app_version'] = profile_data.get('client_app_version')
                 user['os_version'] = profile_data.get('client_os_version')
                 user['phone_lang'] = profile_data.get('phone_lang')
+                user['last_location_ts'] = profile_data.get('last_location_ts')
+                user['last_phone_data_ts'] = profile_data.get('last_phone_data_ts')
+                user['last_sync_ts'] = profile_data.get('last_sync_ts')
+                user['last_put_ts'] = profile_data.get('last_put_ts')
+                user['last_diary_fetch_ts'] = profile_data.get('last_diary_fetch_ts')
                 
                 # Assign newly stored statistics to the user dictionary
                 user['total_trips'] = profile_data.get('total_trips')

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -453,6 +453,8 @@ def add_user_stats(user_data, batch_size=5):
                 user['last_sync_ts'] = profile_data.get('last_sync_ts')
                 user['last_put_ts'] = profile_data.get('last_put_ts')
                 user['last_diary_fetch_ts'] = profile_data.get('last_diary_fetch_ts')
+                user['create_ts'] = profile_data.get('create_ts')
+                user['update_ts'] = profile_data.get('update_ts')
                 
                 # Assign newly stored statistics to the user dictionary
                 user['total_trips'] = profile_data.get('total_trips')


### PR DESCRIPTION
Small changes that add new uuids fields implemented in:
https://github.com/e-mission/e-mission-server/pull/1023
https://github.com/e-mission/e-mission-server/pull/1024
to the dashboard.

The table is wide/columns are not in proper order but that should be fixed by #157 . (157 DOES NOT BLOCK THIS; just makes it look better)

<img width="1724" alt="Screenshot 2025-02-12 at 12 03 32 PM" src="https://github.com/user-attachments/assets/b27a6516-14a0-4251-a803-fb8a74a00c3d" />

<img width="1724" alt="Screenshot 2025-02-12 at 10 40 30 PM" src="https://github.com/user-attachments/assets/7f67c888-8bc2-41a7-87fa-224d30a5c779" />
